### PR TITLE
Allow DELETE requests to have a body

### DIFF
--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ApacheHttpRequestConverter.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ApacheHttpRequestConverter.java
@@ -1,10 +1,6 @@
 package com.hubspot.horizon.apache.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hubspot.horizon.Header;
-import com.hubspot.horizon.HttpRequest;
 import org.apache.http.HttpEntityEnclosingRequest;
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPatch;
@@ -12,6 +8,10 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ByteArrayEntity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.horizon.Header;
+import com.hubspot.horizon.HttpRequest;
 
 public final class ApacheHttpRequestConverter {
   private final ObjectMapper mapper;
@@ -34,7 +34,7 @@ public final class ApacheHttpRequestConverter {
         apacheRequest = new HttpPut(request.getUrl());
         break;
       case DELETE:
-        apacheRequest = new HttpDelete(request.getUrl());
+        apacheRequest = new HttpDeleteWithBody(request.getUrl());
         break;
       case PATCH:
         apacheRequest = new HttpPatch(request.getUrl());

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ApacheHttpRequestConverter.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ApacheHttpRequestConverter.java
@@ -1,5 +1,8 @@
 package com.hubspot.horizon.apache.internal;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.horizon.Header;
+import com.hubspot.horizon.HttpRequest;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -8,10 +11,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ByteArrayEntity;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hubspot.horizon.Header;
-import com.hubspot.horizon.HttpRequest;
 
 public final class ApacheHttpRequestConverter {
   private final ObjectMapper mapper;

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/HttpDeleteWithBody.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/HttpDeleteWithBody.java
@@ -1,10 +1,10 @@
 package com.hubspot.horizon.apache.internal;
 
-import java.net.URI;
-
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
 
 @NotThreadSafe
 public class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/HttpDeleteWithBody.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/HttpDeleteWithBody.java
@@ -1,0 +1,28 @@
+package com.hubspot.horizon.apache.internal;
+
+import java.net.URI;
+
+import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+@NotThreadSafe
+public class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+  public String getMethod() {
+    return HttpDelete.METHOD_NAME;
+  }
+
+  public HttpDeleteWithBody(final String uri) {
+    super();
+    setURI(URI.create(uri));
+  }
+
+  public HttpDeleteWithBody(final URI uri) {
+    super();
+    setURI(uri);
+  }
+
+  public HttpDeleteWithBody() {
+    super();
+  }
+}

--- a/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
+++ b/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
@@ -151,4 +151,18 @@ public class ApacheHttpClientTest {
 
     assertThat(response).hasStatusCode(200).hasBody("test").hasRetries(0).isSnappyCompressed();
   }
+
+  @Test
+  public void itSupportsDeleteWithBody() {
+    httpClient = new ApacheHttpClient();
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .setMethod(Method.DELETE)
+        .setUrl(testServer.baseHttpUrl())
+        .setBody(ExpectedHttpResponse.newBuilder().setBody("test").build())
+        .build();
+    HttpResponse response = httpClient.execute(request);
+
+    assertThat(response).hasStatusCode(200).hasBody("test").hasRetries(0);
+  }
 }

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpRequest.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpRequest.java
@@ -36,7 +36,7 @@ public class HttpRequest {
   }
 
   public enum Method {
-    GET(false), POST(true), PUT(true), DELETE(false), PATCH(true), HEAD(false);
+    GET(false), POST(true), PUT(true), DELETE(true), PATCH(true), HEAD(false);
 
     private final boolean allowsBody;
 

--- a/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
+++ b/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
@@ -152,4 +152,18 @@ public class NingAsyncHttpClientTest {
 
     assertThat(response).hasStatusCode(200).hasBody("test").hasRetries(0).isSnappyCompressed();
   }
+
+  @Test
+  public void itSupportsDeleteWithBody() throws Exception {
+    httpClient = new NingAsyncHttpClient();
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .setMethod(Method.DELETE)
+        .setUrl(testServer.baseHttpUrl())
+        .setBody(ExpectedHttpResponse.newBuilder().setBody("test").build())
+        .build();
+    HttpResponse response = httpClient.execute(request).get();
+
+    assertThat(response).hasStatusCode(200).hasBody("test").hasRetries(0);
+  }
 }


### PR DESCRIPTION
Though not all HTTP server implementations support it, you *can* include a body in DELETE request in HTTP 1.1 (http://stackoverflow.com/a/299696).

In our specific case, we need to make SingularityClient changes work properly in HubSpot/Singularity#810.

/cc @wsorenson 