### PR TITLE
Don't override Content/Accept Encoding headers if already set

### DIFF
--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/DefaultHeadersRequestInterceptor.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/DefaultHeadersRequestInterceptor.java
@@ -1,10 +1,11 @@
 package com.hubspot.horizon.apache.internal;
 
-import com.google.common.net.HttpHeaders;
-import com.hubspot.horizon.HttpConfig;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
+
+import com.google.common.net.HttpHeaders;
+import com.hubspot.horizon.HttpConfig;
 
 public class DefaultHeadersRequestInterceptor implements HttpRequestInterceptor {
   private final HttpConfig config;
@@ -15,7 +16,11 @@ public class DefaultHeadersRequestInterceptor implements HttpRequestInterceptor 
 
   @Override
   public void process(HttpRequest request, HttpContext context) {
-    request.addHeader(HttpHeaders.ACCEPT_ENCODING, "snappy,gzip,deflate");
-    request.addHeader(HttpHeaders.USER_AGENT, config.getUserAgent());
+    if (!request.containsHeader(HttpHeaders.ACCEPT_ENCODING)) {
+      request.addHeader(HttpHeaders.ACCEPT_ENCODING, "snappy,gzip,deflate");
+    }
+    if (!request.containsHeader(HttpHeaders.USER_AGENT)) {
+      request.addHeader(HttpHeaders.USER_AGENT, config.getUserAgent());
+    }
   }
 }

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/AcceptEncodingRequestFilter.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/AcceptEncodingRequestFilter.java
@@ -8,7 +8,9 @@ public class AcceptEncodingRequestFilter implements RequestFilter {
 
   @Override
   public FilterContext filter(FilterContext context) {
-    context.getRequest().getHeaders().add(HttpHeaders.CONTENT_ENCODING, "snappy,gzip,deflate");
+    if (!context.getRequest().getHeaders().containsKey(HttpHeaders.CONTENT_ENCODING)) {
+      context.getRequest().getHeaders().add(HttpHeaders.CONTENT_ENCODING, "snappy,gzip,deflate");
+    }
     return context;
   }
 }


### PR DESCRIPTION
@jhaber I believe this should do what I was looking for. I put it in place for both the Apache and Ning clients for Accept/Content Encoding headers. Can write some tests for it shortly