### PR TITLE
Make sure to release all the client resources

### DIFF
--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -1,5 +1,24 @@
 package com.hubspot.horizon.ning;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.netty.channel.socket.nio.BossPool;
+import org.jboss.netty.channel.socket.nio.NioClientBoss;
+import org.jboss.netty.channel.socket.nio.NioClientBossPool;
+import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioWorker;
+import org.jboss.netty.channel.socket.nio.NioWorkerPool;
+import org.jboss.netty.channel.socket.nio.WorkerPool;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.ThreadNameDeterminer;
+import org.jboss.netty.util.ThreadRenamingRunnable;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -22,21 +41,10 @@ import com.ning.http.client.AsyncHttpProviderConfig;
 import com.ning.http.client.Request;
 import com.ning.http.client.extra.ThrottleRequestFilter;
 import com.ning.http.client.providers.netty.NettyAsyncHttpProviderConfig;
-import org.jboss.netty.channel.socket.nio.NioClientBossPool;
-import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
-import org.jboss.netty.channel.socket.nio.NioWorkerPool;
-import org.jboss.netty.util.HashedWheelTimer;
-import org.jboss.netty.util.ThreadNameDeterminer;
-import org.jboss.netty.util.ThreadRenamingRunnable;
-import org.jboss.netty.util.Timer;
-
-import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 public class NingAsyncHttpClient implements AsyncHttpClient {
   private static final ExecutorService BOSS_EXECUTOR = newExecutor("NioBoss");
+  private static final HashedWheelTimer TIMER = new HashedWheelTimer(newThreadFactory("NioTimer"));
 
   static {
     ThreadRenamingRunnable.setThreadNameDeterminer(ThreadNameDeterminer.CURRENT);
@@ -46,6 +54,8 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
   private final NingHttpRequestConverter requestConverter;
   private final Options defaultOptions;
   private final ObjectMapper mapper;
+  private final NioClientSocketChannelFactory channelFactory;
+  private final ExecutorService workerExecutorService;
 
   public NingAsyncHttpClient() {
     this(HttpConfig.newBuilder().build());
@@ -53,6 +63,13 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
 
   public NingAsyncHttpClient(HttpConfig config) {
     Preconditions.checkNotNull(config);
+
+    NettyAsyncHttpProviderConfig nettyConfig = new NettyAsyncHttpProviderConfig();
+    int workerThreads = Math.min(Runtime.getRuntime().availableProcessors(), 4);
+    this.workerExecutorService = newWorkerThreadPool(workerThreads);
+    this.channelFactory = newSocketChannelFactory(this.workerExecutorService, workerThreads);
+    nettyConfig.setSocketChannelFactory(this.channelFactory);
+    nettyConfig.setNettyTimer(TIMER);
 
     AsyncHttpClientConfig ningConfig = new AsyncHttpClientConfig.Builder()
             .addRequestFilter(new ThrottleRequestFilter(config.getMaxConnections()))
@@ -65,7 +82,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
             .setFollowRedirect(config.isFollowRedirects())
             .setHostnameVerifier(new NingHostnameVerifier(config.getSSLConfig()))
             .setSSLContext(NingSSLContext.forConfig(config.getSSLConfig()))
-            .setAsyncHttpClientProviderConfig(newAsyncProviderConfig())
+            .setAsyncHttpClientProviderConfig(nettyConfig)
             .setUserAgent(config.getUserAgent())
             .setIOThreadMultiplier(1)
             .build();
@@ -123,25 +140,31 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
     return future;
   }
 
-  private static AsyncHttpProviderConfig<?, ?> newAsyncProviderConfig() {
-    NettyAsyncHttpProviderConfig nettyConfig = new NettyAsyncHttpProviderConfig();
-    nettyConfig.setSocketChannelFactory(newSocketChannelFactory());
-    nettyConfig.setNettyTimer(newTimer());
-    return nettyConfig;
+  private static ExecutorService newWorkerThreadPool(int threads) {
+    ThreadPoolExecutor workerPool = new ThreadPoolExecutor(
+            threads,
+            threads,
+            60L,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<Runnable>(),
+            newThreadFactory("NioWorker")
+    );
+
+    workerPool.allowCoreThreadTimeOut(true);
+    return workerPool;
   }
 
-  private static NioClientSocketChannelFactory newSocketChannelFactory() {
-    NioClientBossPool bossPool = new NioClientBossPool(BOSS_EXECUTOR, 1, newTimer(), ThreadNameDeterminer.CURRENT);
-    NioWorkerPool workerPool = new NioWorkerPool(newExecutor("NioWorker"), 5, ThreadNameDeterminer.CURRENT);
+  private static NioClientSocketChannelFactory newSocketChannelFactory(
+          ExecutorService workerThreadPool,
+          int workerThreads
+  ) {
+    BossPool<NioClientBoss> bossPool = new NioClientBossPool(BOSS_EXECUTOR, 1, TIMER, null);
+    WorkerPool<NioWorker> workerPool = new NioWorkerPool(workerThreadPool, workerThreads);
     return new NioClientSocketChannelFactory(bossPool, workerPool);
   }
 
   private static ExecutorService newExecutor(String qualifier) {
     return Executors.newCachedThreadPool(newThreadFactory(qualifier));
-  }
-
-  private static Timer newTimer() {
-    return new HashedWheelTimer(newThreadFactory("HashedWheelTimer"));
   }
 
   private static ThreadFactory newThreadFactory(String qualifier) {
@@ -151,6 +174,16 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
 
   @Override
   public void close() throws IOException {
-    ningClient.close();
+    try {
+      ningClient.close();
+    } finally {
+      // Do NOT call releaseExternalResources() here
+      // since we maintain our own executors.
+      try {
+        channelFactory.shutdown();
+      } finally {
+        workerExecutorService.shutdown();
+      }
+    }
   }
 }


### PR DESCRIPTION
Previously each client would leak a few threads, so if you were frequently creating new clients it would build up over time