### PR TITLE
Add connection TTL option

### DIFF
--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -63,6 +64,7 @@ public class ApacheHttpClient implements HttpClient {
     builder.setConnectionManager(createConnectionManager(config));
     builder.setRedirectStrategy(new LenientRedirectStrategy());
     builder.setKeepAliveStrategy(new KeepAliveWithDefaultStrategy(config.getDefaultKeepAliveMillis()));
+    builder.setConnectionTimeToLive(config.getConnectionTtlMillis(), TimeUnit.MILLISECONDS);
     builder.addInterceptorFirst(new DefaultHeadersRequestInterceptor(config));
     builder.addInterceptorFirst(new SnappyContentEncodingResponseInterceptor());
     builder.setDefaultRequestConfig(createRequestConfig(config));

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -13,7 +13,7 @@ public class HttpConfig {
   private final int connectTimeoutSeconds;
   private final int requestTimeoutSeconds;
   private final int defaultKeepAliveSeconds;
-  private final int connectionTtl;
+  private final int connectionTtlSeconds;
   private final int maxRedirects;
   private final String userAgent;
   private final boolean followRedirects;
@@ -30,7 +30,7 @@ public class HttpConfig {
                      int connectTimeoutSeconds,
                      int requestTimeoutSeconds,
                      int defaultKeepAliveSeconds,
-                     int connectionTtl,
+                     int connectionTtlSeconds,
                      int maxRedirects,
                      String userAgent,
                      boolean followRedirects,
@@ -46,7 +46,7 @@ public class HttpConfig {
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.requestTimeoutSeconds = requestTimeoutSeconds;
     this.defaultKeepAliveSeconds = defaultKeepAliveSeconds;
-    this.connectionTtl = connectionTtl;
+    this.connectionTtlSeconds = connectionTtlSeconds;
     this.maxRedirects = maxRedirects;
     this.userAgent = userAgent;
     this.followRedirects = followRedirects;
@@ -84,7 +84,7 @@ public class HttpConfig {
   }
 
   public int getConnectionTtlMillis() {
-    return Ints.checkedCast(TimeUnit.SECONDS.toMillis(connectionTtl));
+    return Ints.checkedCast(TimeUnit.SECONDS.toMillis(connectionTtlSeconds));
   }
 
   public int getMaxRedirects() {
@@ -128,7 +128,7 @@ public class HttpConfig {
     private int connectTimeoutSeconds = 1;
     private int requestTimeoutSeconds = 30;
     private int defaultKeepAliveSeconds = 10;
-    private int connectionTtl = -1;
+    private int connectionTtlSeconds = -1;
     private int maxRedirects = 10;
     private String userAgent = "Horizon/0.0.1";
     private boolean followRedirects = true;
@@ -167,8 +167,8 @@ public class HttpConfig {
       return this;
     }
 
-    public Builder setConnectionTtl(int connectionTtl) {
-      this.connectionTtl = connectionTtl;
+    public Builder setConnectionTtlSeconds(int connectionTtlSeconds) {
+      this.connectionTtlSeconds = connectionTtlSeconds;
       return this;
     }
 
@@ -228,7 +228,7 @@ public class HttpConfig {
               connectTimeoutSeconds,
               requestTimeoutSeconds,
               defaultKeepAliveSeconds,
-              connectionTtl,
+              connectionTtlSeconds,
               maxRedirects,
               userAgent,
               followRedirects,

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -13,6 +13,7 @@ public class HttpConfig {
   private final int connectTimeoutSeconds;
   private final int requestTimeoutSeconds;
   private final int defaultKeepAliveSeconds;
+  private final int connectionTtl;
   private final int maxRedirects;
   private final String userAgent;
   private final boolean followRedirects;
@@ -29,6 +30,7 @@ public class HttpConfig {
                      int connectTimeoutSeconds,
                      int requestTimeoutSeconds,
                      int defaultKeepAliveSeconds,
+                     int connectionTtl,
                      int maxRedirects,
                      String userAgent,
                      boolean followRedirects,
@@ -44,6 +46,7 @@ public class HttpConfig {
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.requestTimeoutSeconds = requestTimeoutSeconds;
     this.defaultKeepAliveSeconds = defaultKeepAliveSeconds;
+    this.connectionTtl = connectionTtl;
     this.maxRedirects = maxRedirects;
     this.userAgent = userAgent;
     this.followRedirects = followRedirects;
@@ -78,6 +81,10 @@ public class HttpConfig {
 
   public int getDefaultKeepAliveMillis() {
     return Ints.checkedCast(TimeUnit.SECONDS.toMillis(defaultKeepAliveSeconds));
+  }
+
+  public int getConnectionTtlMillis() {
+    return Ints.checkedCast(TimeUnit.SECONDS.toMillis(connectionTtl));
   }
 
   public int getMaxRedirects() {
@@ -121,6 +128,7 @@ public class HttpConfig {
     private int connectTimeoutSeconds = 1;
     private int requestTimeoutSeconds = 30;
     private int defaultKeepAliveSeconds = 10;
+    private int connectionTtl = -1;
     private int maxRedirects = 10;
     private String userAgent = "Horizon/0.0.1";
     private boolean followRedirects = true;
@@ -156,6 +164,11 @@ public class HttpConfig {
 
     public Builder setDefaultKeepAliveSeconds(int defaultKeepAliveSeconds) {
       this.defaultKeepAliveSeconds = defaultKeepAliveSeconds;
+      return this;
+    }
+
+    public Builder setConnectionTtl(int connectionTtl) {
+      this.connectionTtl = connectionTtl;
       return this;
     }
 
@@ -215,6 +228,7 @@ public class HttpConfig {
               connectTimeoutSeconds,
               requestTimeoutSeconds,
               defaultKeepAliveSeconds,
+              connectionTtl,
               maxRedirects,
               userAgent,
               followRedirects,

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -37,7 +37,6 @@ import com.hubspot.horizon.ning.internal.NingHttpRequestConverter;
 import com.hubspot.horizon.ning.internal.NingRetryHandler;
 import com.hubspot.horizon.ning.internal.NingSSLContext;
 import com.ning.http.client.AsyncHttpClientConfig;
-import com.ning.http.client.AsyncHttpProviderConfig;
 import com.ning.http.client.Request;
 import com.ning.http.client.extra.ThrottleRequestFilter;
 import com.ning.http.client.providers.netty.NettyAsyncHttpProviderConfig;
@@ -75,6 +74,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
             .addRequestFilter(new ThrottleRequestFilter(config.getMaxConnections()))
             .addRequestFilter(new AcceptEncodingRequestFilter())
             .setMaxConnectionsPerHost(config.getMaxConnectionsPerHost())
+            .setConnectionTTL(config.getConnectionTtlMillis())
             .setConnectTimeout(config.getConnectTimeoutMillis())
             .setRequestTimeout(config.getRequestTimeoutMillis())
             .setReadTimeout(config.getRequestTimeoutMillis())


### PR DESCRIPTION
Enables configuration of the Connection TTL option for the connection pool on both underlying http clients. This sets the maximum TTL for persistent connections, in both implementations a value of `-1` (the current and previous default) results in connections being held open forever if they're within their `keepAliveSeconds`.