### PR TITLE
Add support for setting a proxy

### DIFF
--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -75,7 +75,7 @@ public class ApacheHttpClient implements HttpClient {
     builder.setDefaultRequestConfig(createRequestConfig(config));
     builder.setDefaultSocketConfig(createSocketConfig(config));
     builder.disableContentCompression();
-    
+
     this.apacheClient = builder.build();
     this.requestConverter = new ApacheHttpRequestConverter(config.getObjectMapper());
     this.config = config;
@@ -99,7 +99,7 @@ public class ApacheHttpClient implements HttpClient {
   private Registry<ConnectionSocketFactory> createSocketFactoryRegistry(HttpConfig config) {
     RegistryBuilder<ConnectionSocketFactory> builder = RegistryBuilder.create();
 
-    if (config.getSocksProxyHost().equals("")) {
+    if (config.isSocksProxied()) {
       builder.register("http", PlainConnectionSocketFactory.getSocketFactory());
       builder.register("https", ApacheSSLSocketFactory.forConfig(config.getSSLConfig()));
     }
@@ -156,7 +156,7 @@ public class ApacheHttpClient implements HttpClient {
 
       final HttpResponse response;
       try {
-        if (config.getSocksProxyHost().equals("")) {
+        if (config.isSocksProxied()) {
           apacheResponse = apacheClient.execute(apacheRequest);
         }
         else {

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -49,7 +49,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ApacheHttpClient implements HttpClient {
   private static final Logger LOG = LoggerFactory.getLogger(ApacheHttpClient.class);
-  private static final int SOCKS_PROXY_PORT = 1080;
 
   private final CloseableHttpClient apacheClient;
   private final ApacheHttpRequestConverter requestConverter;
@@ -83,8 +82,8 @@ public class ApacheHttpClient implements HttpClient {
     this.timer = new Timer("http-request-timeout", true);
   }
 
-  public ApacheHttpClient(String socksProxyHost) {
-    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).build());
+  public ApacheHttpClient(String socksProxyHost, int socksProxyPort) {
+    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).setSocksProxyPort(socksProxyPort).build());
   }
 
   private HttpClientConnectionManager createConnectionManager(HttpConfig config) {
@@ -157,7 +156,7 @@ public class ApacheHttpClient implements HttpClient {
       final HttpResponse response;
       try {
         if (config.isSocksProxied()) {
-          InetSocketAddress socksaddr = new InetSocketAddress(config.getSocksProxyHost(), SOCKS_PROXY_PORT);
+          InetSocketAddress socksaddr = new InetSocketAddress(config.getSocksProxyHost(), config.getSocksProxyPort());
           HttpClientContext context = HttpClientContext.create();
           context.setAttribute("socks.address", socksaddr);
           LOG.info("Sending http request to {} via proxy @{}", request.getUrl(), config.getSocksProxyHost());

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -82,10 +82,6 @@ public class ApacheHttpClient implements HttpClient {
     this.timer = new Timer("http-request-timeout", true);
   }
 
-  public ApacheHttpClient(String socksProxyHost, int socksProxyPort) {
-    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).setSocksProxyPort(socksProxyPort).build());
-  }
-
   private HttpClientConnectionManager createConnectionManager(HttpConfig config) {
     Registry<ConnectionSocketFactory> registry = createSocketFactoryRegistry(config);
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(registry);

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -160,6 +160,7 @@ public class ApacheHttpClient implements HttpClient {
           InetSocketAddress socksaddr = new InetSocketAddress(config.getSocksProxyHost(), SOCKS_PROXY_PORT);
           HttpClientContext context = HttpClientContext.create();
           context.setAttribute("socks.address", socksaddr);
+          LOG.info("Sending http request to {} via proxy @{}", request.getUrl(), config.getSocksProxyHost());
           apacheResponse = apacheClient.execute(apacheRequest, context);
         }
         else {

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -97,8 +97,7 @@ public class ApacheHttpClient implements HttpClient {
     if (config.isSocksProxied()) {
       builder.register("http", ProxiedPlainConnectionSocketFactory.getSocketFactory());
       builder.register("https", ProxiedSSLSocketFactory.forConfig(config.getSSLConfig()));
-    }
-    else {
+    } else {
       builder.register("http", PlainConnectionSocketFactory.getSocketFactory());
       builder.register("https", ApacheSSLSocketFactory.forConfig(config.getSSLConfig()));
     }
@@ -155,10 +154,9 @@ public class ApacheHttpClient implements HttpClient {
           InetSocketAddress socksaddr = new InetSocketAddress(config.getSocksProxyHost(), config.getSocksProxyPort());
           HttpClientContext context = HttpClientContext.create();
           context.setAttribute("socks.address", socksaddr);
-          LOG.info("Sending http request to {} via proxy @{}", request.getUrl(), config.getSocksProxyHost());
+          LOG.debug("Sending http request to {} via proxy @{}", request.getUrl(), config.getSocksProxyHost());
           apacheResponse = apacheClient.execute(apacheRequest, context);
-        }
-        else {
+        } else {
           apacheResponse = apacheClient.execute(apacheRequest);
         }
         response = CachedHttpResponse.from(new ApacheHttpResponse(request, apacheResponse, config.getObjectMapper()));

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -75,8 +75,7 @@ public class ApacheHttpClient implements HttpClient {
     builder.setDefaultRequestConfig(createRequestConfig(config));
     builder.setDefaultSocketConfig(createSocketConfig(config));
     builder.disableContentCompression();
-
-
+    
     this.apacheClient = builder.build();
     this.requestConverter = new ApacheHttpRequestConverter(config.getObjectMapper());
     this.config = config;

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -100,12 +100,12 @@ public class ApacheHttpClient implements HttpClient {
     RegistryBuilder<ConnectionSocketFactory> builder = RegistryBuilder.create();
 
     if (config.isSocksProxied()) {
-      builder.register("http", PlainConnectionSocketFactory.getSocketFactory());
-      builder.register("https", ApacheSSLSocketFactory.forConfig(config.getSSLConfig()));
-    }
-    else {
       builder.register("http", ProxiedPlainConnectionSocketFactory.getSocketFactory());
       builder.register("https", ProxiedSSLSocketFactory.forConfig(config.getSSLConfig()));
+    }
+    else {
+      builder.register("http", PlainConnectionSocketFactory.getSocketFactory());
+      builder.register("https", ApacheSSLSocketFactory.forConfig(config.getSSLConfig()));
     }
 
     return builder.build();
@@ -157,13 +157,13 @@ public class ApacheHttpClient implements HttpClient {
       final HttpResponse response;
       try {
         if (config.isSocksProxied()) {
-          apacheResponse = apacheClient.execute(apacheRequest);
-        }
-        else {
           InetSocketAddress socksaddr = new InetSocketAddress(config.getSocksProxyHost(), SOCKS_PROXY_PORT);
           HttpClientContext context = HttpClientContext.create();
           context.setAttribute("socks.address", socksaddr);
           apacheResponse = apacheClient.execute(apacheRequest, context);
+        }
+        else {
+          apacheResponse = apacheClient.execute(apacheRequest);
         }
         response = CachedHttpResponse.from(new ApacheHttpResponse(request, apacheResponse, config.getObjectMapper()));
       } finally {

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ProxiedPlainConnectionSocketFactory.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ProxiedPlainConnectionSocketFactory.java
@@ -1,0 +1,25 @@
+package com.hubspot.horizon.apache.internal;
+
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+
+public class ProxiedPlainConnectionSocketFactory extends PlainConnectionSocketFactory {
+
+    public static final ProxiedPlainConnectionSocketFactory INSTANCE = new ProxiedPlainConnectionSocketFactory();
+
+    public static ProxiedPlainConnectionSocketFactory getSocketFactory() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Socket createSocket(final HttpContext context) throws IOException {
+        InetSocketAddress socksaddr = (InetSocketAddress) context.getAttribute("socks.address");
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, socksaddr);
+        return new Socket(proxy);
+    }
+}

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ProxiedSSLSocketFactory.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ProxiedSSLSocketFactory.java
@@ -1,0 +1,67 @@
+package com.hubspot.horizon.apache.internal;
+
+import com.hubspot.horizon.SSLConfig;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.ssl.SSLContexts;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+
+public class ProxiedSSLSocketFactory {
+
+    public static SSLConnectionSocketFactory forConfig(SSLConfig config) {
+        try {
+            if (config.isAcceptAllSSL()) {
+                return acceptAllSSLSocketFactory();
+            } else {
+                return standardSSLSocketFactory(config);
+            }
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static SSLConnectionSocketFactory acceptAllSSLSocketFactory() throws GeneralSecurityException {
+        SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, new TrustAllTrustStrategy()).build();
+
+        return new SocksConnectionSocketFactory(sslContext, new NoopHostnameVerifier());
+    }
+
+    private static SSLConnectionSocketFactory standardSSLSocketFactory(SSLConfig config) throws GeneralSecurityException {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(config.getKeyManagers(), config.getTrustManagers(), null);
+
+        return new SocksConnectionSocketFactory(sslContext, new DefaultHostnameVerifier());
+    }
+
+    private static class TrustAllTrustStrategy implements TrustStrategy {
+
+        @Override
+        public boolean isTrusted(X509Certificate[] chain, String authType) {
+            return true;
+        }
+    }
+
+    static class SocksConnectionSocketFactory extends SSLConnectionSocketFactory {
+        public SocksConnectionSocketFactory(SSLContext sslContext, HostnameVerifier hostnameVerifier) {
+            super(sslContext, hostnameVerifier);
+        }
+
+        @Override
+        public Socket createSocket(final HttpContext context) throws IOException {
+            InetSocketAddress socksaddr = (InetSocketAddress) context.getAttribute("socks.address");
+            Proxy proxy = new Proxy(Proxy.Type.SOCKS, socksaddr);
+            return new Socket(proxy);
+        }
+    }
+}

--- a/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
+++ b/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
@@ -7,7 +7,6 @@ import com.hubspot.horizon.HttpConfig;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Method;
 import com.hubspot.horizon.HttpResponse;
-import com.hubspot.horizon.HttpRuntimeException;
 import com.hubspot.horizon.SSLConfig;
 import com.hubspot.horizon.TestServer;
 import org.junit.After;
@@ -16,7 +15,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.SocketException;
 
 import static com.hubspot.horizon.Assertions.assertThat;
 
@@ -56,7 +54,7 @@ public class ApacheHttpClientTest {
 
   @Test(expected = Exception.class)
   public void shouldFailIfInvalidSocksProxyIsConfigured() {
-    httpClient = new ApacheHttpClient("invalidSocksHost");
+    httpClient = new ApacheHttpClient("invalidSocksHost", 1080);
 
     HttpRequest request = HttpRequest.newBuilder()
             .setMethod(Method.POST)

--- a/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
+++ b/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
@@ -53,8 +53,8 @@ public class ApacheHttpClientTest {
   }
 
   @Test(expected = Exception.class)
-  public void shouldFailIfInvalidSocksProxyIsConfigured() {
-    httpClient = new ApacheHttpClient("invalidSocksHost", 1080);
+  public void shouldFailIfInvalidSocksProxyIsConfiguredforHttp() {
+    httpClient = new ApacheHttpClient(HttpConfig.newBuilder().setSocksProxyHost("invalidProxyHost").build());
 
     HttpRequest request = HttpRequest.newBuilder()
             .setMethod(Method.POST)
@@ -76,6 +76,18 @@ public class ApacheHttpClientTest {
     HttpResponse response = httpClient.execute(request);
 
     assertThat(response).hasStatusCode(200).hasBody("").hasRetries(0);
+  }
+
+  @Test(expected = Exception.class)
+  public void shouldFailIfInvalidSocksProxyIsConfiguredforHttps() {
+    httpClient = new ApacheHttpClient(HttpConfig.newBuilder().setSSLConfig(SSLConfig.acceptAll()).setSocksProxyHost("invalidProxyHost").build());
+
+    HttpRequest request = HttpRequest.newBuilder()
+            .setMethod(Method.POST)
+            .setUrl(testServer.baseHttpUrl())
+            .setBody(ExpectedHttpResponse.newBuilder().build())
+            .build();
+    httpClient.execute(request);
   }
 
   @Test

--- a/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
+++ b/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
@@ -7,6 +7,7 @@ import com.hubspot.horizon.HttpConfig;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Method;
 import com.hubspot.horizon.HttpResponse;
+import com.hubspot.horizon.HttpRuntimeException;
 import com.hubspot.horizon.SSLConfig;
 import com.hubspot.horizon.TestServer;
 import org.junit.After;
@@ -15,6 +16,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.SocketException;
 
 import static com.hubspot.horizon.Assertions.assertThat;
 
@@ -50,6 +52,18 @@ public class ApacheHttpClientTest {
     HttpResponse response = httpClient.execute(request);
 
     assertThat(response).hasStatusCode(200).hasBody("").hasRetries(0);
+  }
+
+  @Test(expected = HttpRuntimeException.class)
+  public void shouldFailIfInvalidSocksProxyIsConfigured() {
+    httpClient = new ApacheHttpClient("invalidSocksHost");
+
+    HttpRequest request = HttpRequest.newBuilder()
+            .setMethod(Method.POST)
+            .setUrl(testServer.baseHttpUrl())
+            .setBody(ExpectedHttpResponse.newBuilder().build())
+            .build();
+    httpClient.execute(request);
   }
 
   @Test

--- a/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
+++ b/HorizonApache/src/test/java/com/hubspot/horizon/apache/ApacheHttpClientTest.java
@@ -54,7 +54,7 @@ public class ApacheHttpClientTest {
     assertThat(response).hasStatusCode(200).hasBody("").hasRetries(0);
   }
 
-  @Test(expected = HttpRuntimeException.class)
+  @Test(expected = Exception.class)
   public void shouldFailIfInvalidSocksProxyIsConfigured() {
     httpClient = new ApacheHttpClient("invalidSocksHost");
 

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -116,6 +116,8 @@ public class HttpConfig {
 
   public String getSocksProxyHost() { return socksProxyHost; }
 
+  public boolean isSocksProxied() { return !getSocksProxyHost().equals(""); }
+
   public Options getOptions() {
     Options options = new Options();
 

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -24,6 +24,7 @@ public class HttpConfig {
   private final RetryStrategy retryStrategy;
   private final ObjectMapper mapper;
   private final SSLConfig sslConfig;
+  private final String socksProxyHost;
 
   private HttpConfig(int maxConnections,
                      int maxConnectionsPerHost,
@@ -40,7 +41,8 @@ public class HttpConfig {
                      int maxRetryBackoffSeconds,
                      RetryStrategy retryStrategy,
                      ObjectMapper mapper,
-                     SSLConfig sslConfig) {
+                     SSLConfig sslConfig,
+                     String socksProxyHost) {
     this.maxConnections = maxConnections;
     this.maxConnectionsPerHost = maxConnectionsPerHost;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
@@ -57,6 +59,7 @@ public class HttpConfig {
     this.retryStrategy = retryStrategy;
     this.mapper = mapper;
     this.sslConfig = sslConfig;
+    this.socksProxyHost = socksProxyHost;
   }
 
   public static Builder newBuilder() {
@@ -111,6 +114,8 @@ public class HttpConfig {
     return sslConfig;
   }
 
+  public String getSocksProxyHost() { return socksProxyHost; }
+
   public Options getOptions() {
     Options options = new Options();
 
@@ -139,6 +144,7 @@ public class HttpConfig {
     private RetryStrategy retryStrategy = RetryStrategy.DEFAULT;
     private ObjectMapper mapper = new ObjectMapper();
     private SSLConfig sslConfig = SSLConfig.standard();
+    private String socksProxyHost = "";
 
     private Builder() { }
 
@@ -222,6 +228,11 @@ public class HttpConfig {
       return this;
     }
 
+    public Builder setSocksProxyHost(String socksProxyHost) {
+      this.socksProxyHost = socksProxyHost;
+      return this;
+    }
+
     public HttpConfig build() {
       return new HttpConfig(maxConnections,
               maxConnectionsPerHost,
@@ -238,7 +249,8 @@ public class HttpConfig {
               maxRetryBackoffSeconds,
               retryStrategy,
               mapper,
-              sslConfig);
+              sslConfig,
+              socksProxyHost);
     }
   }
 }

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -25,6 +25,7 @@ public class HttpConfig {
   private final ObjectMapper mapper;
   private final SSLConfig sslConfig;
   private final String socksProxyHost;
+  private final int socksProxyPort;
 
   private HttpConfig(int maxConnections,
                      int maxConnectionsPerHost,
@@ -42,7 +43,8 @@ public class HttpConfig {
                      RetryStrategy retryStrategy,
                      ObjectMapper mapper,
                      SSLConfig sslConfig,
-                     String socksProxyHost) {
+                     String socksProxyHost,
+                     int socksProxyPort) {
     this.maxConnections = maxConnections;
     this.maxConnectionsPerHost = maxConnectionsPerHost;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
@@ -60,6 +62,7 @@ public class HttpConfig {
     this.mapper = mapper;
     this.sslConfig = sslConfig;
     this.socksProxyHost = socksProxyHost;
+    this.socksProxyPort = socksProxyPort;
   }
 
   public static Builder newBuilder() {
@@ -118,6 +121,8 @@ public class HttpConfig {
 
   public boolean isSocksProxied() { return !getSocksProxyHost().equals(""); }
 
+  public int getSocksProxyPort() { return socksProxyPort; }
+
   public Options getOptions() {
     Options options = new Options();
 
@@ -147,6 +152,7 @@ public class HttpConfig {
     private ObjectMapper mapper = new ObjectMapper();
     private SSLConfig sslConfig = SSLConfig.standard();
     private String socksProxyHost = "";
+    private int socksProxyPort = 1080;
 
     private Builder() { }
 
@@ -235,6 +241,11 @@ public class HttpConfig {
       return this;
     }
 
+    public Builder setSocksProxyPort(int socksProxyPort) {
+      this.socksProxyPort = socksProxyPort;
+      return this;
+    }
+
     public HttpConfig build() {
       return new HttpConfig(maxConnections,
               maxConnectionsPerHost,
@@ -252,7 +263,8 @@ public class HttpConfig {
               retryStrategy,
               mapper,
               sslConfig,
-              socksProxyHost);
+              socksProxyHost,
+              socksProxyPort);
     }
   }
 }

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -53,7 +53,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
 
     DefaultAsyncHttpClientConfig.Builder builder = new DefaultAsyncHttpClientConfig.Builder();
 
-    if (!config.isSocksProxied()) {
+    if (config.isSocksProxied()) {
       ProxyServer proxyServer = new ProxyServer.Builder(config.getSocksProxyHost(), 1080).setProxyType(ProxyType.SOCKS_V5).build();
       builder.setProxyServer(proxyServer);
     }

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -32,9 +32,12 @@ import com.hubspot.horizon.ning.internal.NingRetryHandler;
 import com.hubspot.horizon.ning.internal.NingSSLContext;
 import org.asynchttpclient.shaded.proxy.ProxyServer;
 import org.asynchttpclient.shaded.proxy.ProxyType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NingAsyncHttpClient implements AsyncHttpClient {
   private static final HashedWheelTimer TIMER = new HashedWheelTimer(newThreadFactory("NingAsyncHttpClient-Timer"));
+  private static final Logger LOG = LoggerFactory.getLogger(NingAsyncHttpClient.class);
 
   private final org.asynchttpclient.shaded.AsyncHttpClient ningClient;
   private final NingHttpRequestConverter requestConverter;
@@ -54,6 +57,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
     DefaultAsyncHttpClientConfig.Builder builder = new DefaultAsyncHttpClientConfig.Builder();
 
     if (config.isSocksProxied()) {
+      LOG.info("Client is configured for SOCKS proxy @{}", config.getSocksProxyHost());
       ProxyServer proxyServer = new ProxyServer.Builder(config.getSocksProxyHost(), 1080).setProxyType(ProxyType.SOCKS_V5).build();
       builder.setProxyServer(proxyServer);
     }

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -58,7 +58,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
 
     if (config.isSocksProxied()) {
       LOG.info("Client is configured for SOCKS proxy @{}", config.getSocksProxyHost());
-      ProxyServer proxyServer = new ProxyServer.Builder(config.getSocksProxyHost(), 1080).setProxyType(ProxyType.SOCKS_V5).build();
+      ProxyServer proxyServer = new ProxyServer.Builder(config.getSocksProxyHost(), config.getSocksProxyPort()).setProxyType(ProxyType.SOCKS_V5).build();
       builder.setProxyServer(proxyServer);
     }
 
@@ -86,8 +86,8 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
     this.mapper = config.getObjectMapper();
   }
 
-  public NingAsyncHttpClient(String socksProxyHost) {
-    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).build());
+  public NingAsyncHttpClient(String socksProxyHost, int socksProxyPort) {
+    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).setSocksProxyPort(socksProxyPort).build());
   }
 
   @Override

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -53,7 +53,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
 
     DefaultAsyncHttpClientConfig.Builder builder = new DefaultAsyncHttpClientConfig.Builder();
 
-    if (!config.getSocksProxyHost().equals("")) {
+    if (!config.isSocksProxied()) {
       ProxyServer proxyServer = new ProxyServer.Builder(config.getSocksProxyHost(), 1080).setProxyType(ProxyType.SOCKS_V5).build();
       builder.setProxyServer(proxyServer);
     }

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -86,10 +86,6 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
     this.mapper = config.getObjectMapper();
   }
 
-  public NingAsyncHttpClient(String socksProxyHost, int socksProxyPort) {
-    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).setSocksProxyPort(socksProxyPort).build());
-  }
-
   @Override
   public ListenableFuture<HttpResponse> execute(HttpRequest request) {
     return execute(Preconditions.checkNotNull(request), Options.DEFAULT);

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingHttpClient.java
@@ -22,8 +22,8 @@ public class NingHttpClient implements HttpClient {
     this.delegate = new NingAsyncHttpClient(Preconditions.checkNotNull(config));
   }
 
-  public NingHttpClient(String socksProxyHost) {
-    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).build());
+  public NingHttpClient(String socksProxyHost, int socksProxyPort) {
+    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).setSocksProxyPort(socksProxyPort).build());
   }
 
   @Override

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingHttpClient.java
@@ -22,6 +22,10 @@ public class NingHttpClient implements HttpClient {
     this.delegate = new NingAsyncHttpClient(Preconditions.checkNotNull(config));
   }
 
+  public NingHttpClient(String socksProxyHost) {
+    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).build());
+  }
+
   @Override
   public HttpResponse execute(HttpRequest request) throws HttpRuntimeException {
     return execute(Preconditions.checkNotNull(request), Options.DEFAULT);

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingHttpClient.java
@@ -22,10 +22,6 @@ public class NingHttpClient implements HttpClient {
     this.delegate = new NingAsyncHttpClient(Preconditions.checkNotNull(config));
   }
 
-  public NingHttpClient(String socksProxyHost, int socksProxyPort) {
-    this(HttpConfig.newBuilder().setSocksProxyHost(socksProxyHost).setSocksProxyPort(socksProxyPort).build());
-  }
-
   @Override
   public HttpResponse execute(HttpRequest request) throws HttpRuntimeException {
     return execute(Preconditions.checkNotNull(request), Options.DEFAULT);

--- a/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
+++ b/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
@@ -6,7 +6,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.util.concurrent.ExecutionException;
 
+import com.hubspot.horizon.HttpRuntimeException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -71,6 +73,18 @@ public class NingAsyncHttpClientTest {
     HttpResponse response = httpClient.execute(request).get();
 
     assertThat(response).hasStatusCode(200).hasBody("").hasRetries(0);
+  }
+
+  @Test(expected = Exception.class)
+  public void shouldFailIfInvalidSocksProxyIsConfigured() throws Exception {
+    httpClient = new NingAsyncHttpClient("invalidSocksHost");
+
+    HttpRequest request = HttpRequest.newBuilder()
+            .setMethod(Method.POST)
+            .setUrl(testServer.baseHttpUrl())
+            .setBody(ExpectedHttpResponse.newBuilder().build())
+            .build();
+    httpClient.execute(request).get();
   }
 
   @Test

--- a/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
+++ b/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
@@ -58,6 +58,18 @@ public class NingAsyncHttpClientTest {
     assertThat(response).hasStatusCode(200).hasBody("").hasRetries(0);
   }
 
+  @Test(expected = Exception.class)
+  public void shouldFailIfInvalidSocksProxyIsConfiguredForHttp() throws Exception {
+    httpClient = new NingAsyncHttpClient(HttpConfig.newBuilder().setSocksProxyHost("invalidSocksHost").build());
+
+    HttpRequest request = HttpRequest.newBuilder()
+            .setMethod(Method.POST)
+            .setUrl(testServer.baseHttpUrl())
+            .setBody(ExpectedHttpResponse.newBuilder().build())
+            .build();
+    httpClient.execute(request).get();
+  }
+
   @Test
   @Ignore
   public void itWorksWithHttps() throws Exception {
@@ -74,8 +86,8 @@ public class NingAsyncHttpClientTest {
   }
 
   @Test(expected = Exception.class)
-  public void shouldFailIfInvalidSocksProxyIsConfigured() throws Exception {
-    httpClient = new NingAsyncHttpClient("invalidSocksHost", 1080);
+  public void shouldFailIfInvalidSocksProxyIsConfiguredForHttps() throws Exception {
+    httpClient = new NingAsyncHttpClient(HttpConfig.newBuilder().setSSLConfig(SSLConfig.acceptAll()).setSocksProxyHost("invalidSocksHost").build());
 
     HttpRequest request = HttpRequest.newBuilder()
             .setMethod(Method.POST)

--- a/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
+++ b/HorizonNing/src/test/java/com/hubspot/horizong/ning/NingAsyncHttpClientTest.java
@@ -6,9 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
-import java.util.concurrent.ExecutionException;
 
-import com.hubspot.horizon.HttpRuntimeException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -77,7 +75,7 @@ public class NingAsyncHttpClientTest {
 
   @Test(expected = Exception.class)
   public void shouldFailIfInvalidSocksProxyIsConfigured() throws Exception {
-    httpClient = new NingAsyncHttpClient("invalidSocksHost");
+    httpClient = new NingAsyncHttpClient("invalidSocksHost", 1080);
 
     HttpRequest request = HttpRequest.newBuilder()
             .setMethod(Method.POST)


### PR DESCRIPTION
Our horizon http clients don't support setting a proxy. This adds support for setting a proxy on initialization via HTTPConfig or constructor.

@kenbreeman @stevegutz 