### PR TITLE
Expose client using socks proxy publicly

### DIFF
--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -82,7 +82,7 @@ public class ApacheHttpClient implements HttpClient {
     this.timer = new Timer("http-request-timeout", true);
   }
   
-  public boolean usesSocksProxy() {
+  public boolean isSocksProxied() {
     return config.isSocksProxied();
   }
 

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -81,6 +81,10 @@ public class ApacheHttpClient implements HttpClient {
     this.defaultOptions = config.getOptions();
     this.timer = new Timer("http-request-timeout", true);
   }
+  
+  public boolean usesSocksProxy() {
+    return config.isSocksProxied();
+  }
 
   private HttpClientConnectionManager createConnectionManager(HttpConfig config) {
     Registry<ConnectionSocketFactory> registry = createSocketFactoryRegistry(config);


### PR DESCRIPTION
Sometimes, we would like to examine the client to check if it uses a SOCKS proxy. Consider the case if the client is mysteriously blocked by a SOCKS proxy and we expect the client to be not be configured to use the proxy.

@stevegutz @kenbreeman