### PR TITLE
Add support for per-request timeouts

### DIFF
--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/ApacheHttpClient.java
@@ -161,7 +161,7 @@ public class ApacheHttpClient implements HttpClient {
     int maxRetries = options.getMaxRetries();
     RetryStrategy retryStrategy = options.getRetryStrategy();
 
-    HttpUriRequest apacheRequest = requestConverter.convert(request);
+    HttpUriRequest apacheRequest = requestConverter.convert(request, options);
     org.apache.http.HttpResponse apacheResponse = null;
     AtomicBoolean timedOut = new AtomicBoolean(false);
     try {

--- a/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ApacheHttpRequestConverter.java
+++ b/HorizonApache/src/main/java/com/hubspot/horizon/apache/internal/ApacheHttpRequestConverter.java
@@ -1,27 +1,42 @@
 package com.hubspot.horizon.apache.internal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.Ints;
 import com.hubspot.horizon.Header;
 import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.HttpRequest.Options;
+import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ByteArrayEntity;
 
 public final class ApacheHttpRequestConverter {
 
   private final ObjectMapper mapper;
+  private final RequestConfig requestConfig;
 
   public ApacheHttpRequestConverter(ObjectMapper mapper) {
+    this(mapper, RequestConfig.DEFAULT);
+  }
+
+  public ApacheHttpRequestConverter(ObjectMapper mapper, RequestConfig requestConfig) {
     this.mapper = mapper;
+    this.requestConfig = requestConfig;
   }
 
   public HttpUriRequest convert(HttpRequest request) {
-    final HttpUriRequest apacheRequest;
+    return convert(request, Options.DEFAULT);
+  }
+
+  public HttpUriRequest convert(HttpRequest request, Options options) {
+    final HttpRequestBase apacheRequest;
 
     switch (request.getMethod()) {
       case GET:
@@ -56,6 +71,19 @@ public final class ApacheHttpRequestConverter {
     for (Header header : request.getHeaders()) {
       apacheRequest.addHeader(header.getName(), header.getValue());
     }
+
+    options
+      .getRequestTimeoutSeconds()
+      .ifPresent(requestTimeoutSeconds -> {
+        apacheRequest.setConfig(
+          RequestConfig
+            .copy(requestConfig)
+            .setSocketTimeout(
+              Ints.checkedCast(TimeUnit.SECONDS.toMillis(requestTimeoutSeconds))
+            )
+            .build()
+        );
+      });
 
     return apacheRequest;
   }

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -135,6 +135,7 @@ public class HttpConfig {
   public Options getOptions() {
     Options options = new Options();
 
+    options.setRequestTimeoutSeconds(requestTimeoutSeconds);
     options.setMaxRetries(maxRetries);
     options.setInitialRetryBackoffSeconds(initialRetryBackoffSeconds);
     options.setMaxRetryBackoffSeconds(maxRetryBackoffSeconds);

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/NingAsyncHttpClient.java
@@ -136,7 +136,7 @@ public class NingAsyncHttpClient implements AsyncHttpClient {
       retryHandler,
       mapper
     );
-    final Request ningRequest = requestConverter.convert(request);
+    final Request ningRequest = requestConverter.convert(request, options);
     Runnable runnable = () -> {
       try {
         ningClient.executeRequest(ningRequest, completionHandler);

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpRequestConverter.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpRequestConverter.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.net.HttpHeaders;
+import com.google.common.primitives.Ints;
 import com.hubspot.horizon.Header;
 import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.HttpRequest.Options;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.asynchttpclient.shaded.Request;
 import org.asynchttpclient.shaded.RequestBuilder;
 import org.asynchttpclient.shaded.io.netty.handler.codec.http.cookie.DefaultCookie;
@@ -25,6 +28,10 @@ public final class NingHttpRequestConverter {
   }
 
   public Request convert(HttpRequest request) {
+    return convert(request, Options.DEFAULT);
+  }
+
+  public Request convert(HttpRequest request, Options options) {
     RequestBuilder ningRequest = new RequestBuilder(request.getMethod().name());
     ningRequest.setUrl(request.getUrl().toString());
 
@@ -52,6 +59,17 @@ public final class NingHttpRequestConverter {
         ningRequest.addHeader(name, header.getValue());
       }
     }
+
+    options
+      .getRequestTimeoutSeconds()
+      .ifPresent(requestTimeoutSeconds -> {
+        int requestTimeoutMillis = Ints.checkedCast(
+          TimeUnit.SECONDS.toMillis(requestTimeoutSeconds)
+        );
+
+        ningRequest.setRequestTimeout(requestTimeoutMillis);
+        ningRequest.setReadTimeout(requestTimeoutMillis);
+      });
 
     return ningRequest.build();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
   </modules>
 
   <properties>
+    <project.build.targetJdk>11</project.build.targetJdk>
+    <project.build.sourceJdk>11</project.build.sourceJdk>
+    <project.build.releaseJdk>11</project.build.releaseJdk>
+    <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+
     <dep.slf4j.version>1.7.30</dep.slf4j.version>
   </properties>
 


### PR DESCRIPTION
I need to add some unit tests but this theoretically allows clients to specify per-request timeouts, which is somewhat niche but a lifesaver when you do it need it 😄 

@stevie400 @Xcelled @suruuK