### PR TITLE
add optional dns resolution post processor

### DIFF
--- a/HorizonCore/src/main/java/com/hubspot/horizon/DnsResolutionPostProcessor.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/DnsResolutionPostProcessor.java
@@ -1,0 +1,10 @@
+package com.hubspot.horizon;
+
+import java.net.InetAddress;
+import java.util.List;
+
+public interface DnsResolutionPostProcessor {
+  InetAddress postResolve(InetAddress address);
+
+  List<InetAddress> postResolveAll(List<InetAddress> addresses);
+}

--- a/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
+++ b/HorizonCore/src/main/java/com/hubspot/horizon/HttpConfig.java
@@ -27,6 +27,7 @@ public class HttpConfig {
   private final SSLConfig sslConfig;
   private final Optional<String> socksProxyHost;
   private final int socksProxyPort;
+  private final Optional<DnsResolutionPostProcessor> dnsResolutionPostProcessor;
 
   private HttpConfig(
     int maxConnections,
@@ -46,7 +47,8 @@ public class HttpConfig {
     ObjectMapper mapper,
     SSLConfig sslConfig,
     Optional<String> socksProxyHost,
-    int socksProxyPort
+    int socksProxyPort,
+    Optional<DnsResolutionPostProcessor> dnsResolutionPostProcessor
   ) {
     this.maxConnections = maxConnections;
     this.maxConnectionsPerHost = maxConnectionsPerHost;
@@ -66,6 +68,7 @@ public class HttpConfig {
     this.sslConfig = sslConfig;
     this.socksProxyHost = socksProxyHost;
     this.socksProxyPort = socksProxyPort;
+    this.dnsResolutionPostProcessor = dnsResolutionPostProcessor;
   }
 
   public static Builder newBuilder() {
@@ -132,6 +135,10 @@ public class HttpConfig {
     return socksProxyPort;
   }
 
+  public Optional<DnsResolutionPostProcessor> getDnsResolutionPostProcessor() {
+    return dnsResolutionPostProcessor;
+  }
+
   public Options getOptions() {
     Options options = new Options();
 
@@ -163,6 +170,8 @@ public class HttpConfig {
     private SSLConfig sslConfig = SSLConfig.standard();
     private Optional<String> socksProxyHost = Optional.empty();
     private int socksProxyPort = 1080;
+    private Optional<DnsResolutionPostProcessor> dnsResolutionPostProcessor =
+      Optional.empty();
 
     private Builder() {}
 
@@ -256,6 +265,13 @@ public class HttpConfig {
       return this;
     }
 
+    public Builder setDnsResolutionPostProcessor(
+      DnsResolutionPostProcessor dnsResolutionPostProcessor
+    ) {
+      this.dnsResolutionPostProcessor = Optional.of(dnsResolutionPostProcessor);
+      return this;
+    }
+
     public HttpConfig build() {
       return new HttpConfig(
         maxConnections,
@@ -275,7 +291,8 @@ public class HttpConfig {
         mapper,
         sslConfig,
         socksProxyHost,
-        socksProxyPort
+        socksProxyPort,
+        dnsResolutionPostProcessor
       );
     }
   }

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NameResolverWithPostProcessing.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NameResolverWithPostProcessing.java
@@ -1,0 +1,50 @@
+package com.hubspot.horizon.ning.internal;
+
+import com.hubspot.horizon.DnsResolutionPostProcessor;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import org.asynchttpclient.shaded.io.netty.resolver.InetNameResolver;
+import org.asynchttpclient.shaded.io.netty.util.concurrent.EventExecutor;
+import org.asynchttpclient.shaded.io.netty.util.concurrent.Promise;
+import org.asynchttpclient.shaded.io.netty.util.internal.SocketUtils;
+
+public class NameResolverWithPostProcessing extends InetNameResolver {
+
+  private final DnsResolutionPostProcessor dnsResolutionPostProcessor;
+
+  public NameResolverWithPostProcessing(
+    EventExecutor executor,
+    DnsResolutionPostProcessor dnsResolutionPostProcessor
+  ) {
+    super(executor);
+    this.dnsResolutionPostProcessor = dnsResolutionPostProcessor;
+  }
+
+  @Override
+  protected void doResolve(String inetHost, Promise<InetAddress> promise)
+    throws Exception {
+    try {
+      promise.setSuccess(
+        dnsResolutionPostProcessor.postResolve(SocketUtils.addressByName(inetHost))
+      );
+    } catch (UnknownHostException e) {
+      promise.setFailure(e);
+    }
+  }
+
+  @Override
+  protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise)
+    throws Exception {
+    try {
+      promise.setSuccess(
+        dnsResolutionPostProcessor.postResolveAll(
+          Arrays.asList(SocketUtils.allAddressesByName(inetHost))
+        )
+      );
+    } catch (UnknownHostException e) {
+      promise.setFailure(e);
+    }
+  }
+}

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpRequestConverter.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpRequestConverter.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.net.HttpHeaders;
+import com.hubspot.horizon.DnsResolutionPostProcessor;
 import com.hubspot.horizon.Header;
 import com.hubspot.horizon.HttpRequest;
 import java.util.Map;
+import java.util.Optional;
 import org.asynchttpclient.shaded.Request;
 import org.asynchttpclient.shaded.RequestBuilder;
 import org.asynchttpclient.shaded.io.netty.handler.codec.http.cookie.DefaultCookie;
+import org.asynchttpclient.shaded.io.netty.util.concurrent.ImmediateEventExecutor;
 
 public final class NingHttpRequestConverter {
 
@@ -24,9 +27,20 @@ public final class NingHttpRequestConverter {
     this.mapper = mapper;
   }
 
-  public Request convert(HttpRequest request) {
+  public Request convert(
+    HttpRequest request,
+    Optional<DnsResolutionPostProcessor> dnsResolutionPostProcessor
+  ) {
     RequestBuilder ningRequest = new RequestBuilder(request.getMethod().name());
     ningRequest.setUrl(request.getUrl().toString());
+    if (dnsResolutionPostProcessor.isPresent()) {
+      ningRequest.setNameResolver(
+        new NameResolverWithPostProcessing(
+          ImmediateEventExecutor.INSTANCE,
+          dnsResolutionPostProcessor.get()
+        )
+      );
+    }
 
     byte[] body = request.getBody(mapper);
     if (body != null) {


### PR DESCRIPTION
We would like to be able to make changes to DNS resolution in the horizon client. Specifically, we'd like to resolve the hostname to ips, and then filter down the ips to those in the same availability zone as us, to avoid costly cross-zone traffic. This adds a pluggable interface to do some post-dns-resolution processing