### PR TITLE
Upgrade async-http-client to v3

### DIFF
--- a/HorizonApache/pom.xml
+++ b/HorizonApache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>Horizon</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>HorizonApache</artifactId>

--- a/HorizonCore/pom.xml
+++ b/HorizonCore/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>Horizon</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>HorizonCore</artifactId>

--- a/HorizonNing/pom.xml
+++ b/HorizonNing/pom.xml
@@ -25,6 +25,26 @@
       <artifactId>HorizonCore</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
     </dependency>

--- a/HorizonNing/pom.xml
+++ b/HorizonNing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>Horizon</artifactId>
-    <version>0.3.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>HorizonNing</artifactId>
@@ -22,11 +22,11 @@
     </dependency>
     <dependency>
       <groupId>com.hubspot</groupId>
-      <artifactId>async-http-client-shaded</artifactId>
+      <artifactId>HorizonCore</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.hubspot</groupId>
-      <artifactId>HorizonCore</artifactId>
+      <groupId>org.asynchttpclient</groupId>
+      <artifactId>async-http-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/AcceptEncodingRequestFilter.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/AcceptEncodingRequestFilter.java
@@ -1,8 +1,8 @@
 package com.hubspot.horizon.ning.internal;
 
 import com.google.common.net.HttpHeaders;
-import org.asynchttpclient.shaded.filter.FilterContext;
-import org.asynchttpclient.shaded.filter.RequestFilter;
+import org.asynchttpclient.filter.FilterContext;
+import org.asynchttpclient.filter.RequestFilter;
 
 public class AcceptEncodingRequestFilter implements RequestFilter {
 

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/CustomNingNameResolver.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/CustomNingNameResolver.java
@@ -1,13 +1,13 @@
 package com.hubspot.horizon.ning.internal;
 
 import com.hubspot.horizon.DnsResolver;
+import io.netty.resolver.InetNameResolver;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
-import org.asynchttpclient.shaded.io.netty.resolver.InetNameResolver;
-import org.asynchttpclient.shaded.io.netty.util.concurrent.EventExecutor;
-import org.asynchttpclient.shaded.io.netty.util.concurrent.Promise;
 
 public class CustomNingNameResolver extends InetNameResolver {
 

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/DefaultHeadersRequestFilter.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/DefaultHeadersRequestFilter.java
@@ -2,9 +2,9 @@ package com.hubspot.horizon.ning.internal;
 
 import com.hubspot.horizon.HorizonHeaders;
 import com.hubspot.horizon.HttpConfig;
-import org.asynchttpclient.shaded.filter.FilterContext;
-import org.asynchttpclient.shaded.filter.RequestFilter;
-import org.asynchttpclient.shaded.io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import org.asynchttpclient.filter.FilterContext;
+import org.asynchttpclient.filter.RequestFilter;
 
 public class DefaultHeadersRequestFilter implements RequestFilter {
 

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/GzipHttpResponseWrapper.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/GzipHttpResponseWrapper.java
@@ -1,0 +1,46 @@
+package com.hubspot.horizon.ning.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.hubspot.horizon.Headers;
+import com.hubspot.horizon.HttpRequest;
+import com.hubspot.horizon.internal.AbstractHttpResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+public class GzipHttpResponseWrapper extends AbstractHttpResponse {
+
+  private final AbstractHttpResponse delegate;
+  private final InputStream wrapped;
+
+  public GzipHttpResponseWrapper(AbstractHttpResponse delegate) throws IOException {
+    this.delegate = Preconditions.checkNotNull(delegate);
+    this.wrapped = new GZIPInputStream(delegate.getAsInputStream());
+  }
+
+  @Override
+  public ObjectMapper getObjectMapper() {
+    return delegate.getObjectMapper();
+  }
+
+  @Override
+  public HttpRequest getRequest() {
+    return delegate.getRequest();
+  }
+
+  @Override
+  public int getStatusCode() {
+    return delegate.getStatusCode();
+  }
+
+  @Override
+  public Headers getHeaders() {
+    return delegate.getHeaders();
+  }
+
+  @Override
+  public InputStream getAsInputStream() {
+    return wrapped;
+  }
+}

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingCompletionHandler.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingCompletionHandler.java
@@ -5,9 +5,10 @@ import com.google.common.net.HttpHeaders;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpResponse;
 import com.hubspot.horizon.internal.AbstractHttpResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
-import org.asynchttpclient.shaded.AsyncCompletionHandler;
-import org.asynchttpclient.shaded.Response;
+import org.asynchttpclient.AsyncCompletionHandler;
+import org.asynchttpclient.Response;
 
 public class NingCompletionHandler extends AsyncCompletionHandler<HttpResponse> {
 
@@ -29,10 +30,13 @@ public class NingCompletionHandler extends AsyncCompletionHandler<HttpResponse> 
   }
 
   @Override
+  @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
   public HttpResponse onCompleted(Response ningResponse) throws Exception {
     AbstractHttpResponse response = new NingHttpResponse(request, ningResponse, mapper);
     if ("snappy".equals(ningResponse.getHeader(HttpHeaders.CONTENT_ENCODING))) {
       response = new SnappyHttpResponseWrapper(response);
+    } else if ("gzip".equals(ningResponse.getHeader(HttpHeaders.CONTENT_ENCODING))) {
+      response = new GzipHttpResponseWrapper(response);
     }
     if (retryHandler.shouldRetry(request, response)) {
       retryHandler.retry();

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpRequestConverter.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpRequestConverter.java
@@ -7,12 +7,12 @@ import com.google.common.net.HttpHeaders;
 import com.hubspot.horizon.DnsResolver;
 import com.hubspot.horizon.Header;
 import com.hubspot.horizon.HttpRequest;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import java.util.Map;
 import java.util.Optional;
-import org.asynchttpclient.shaded.Request;
-import org.asynchttpclient.shaded.RequestBuilder;
-import org.asynchttpclient.shaded.io.netty.handler.codec.http.cookie.DefaultCookie;
-import org.asynchttpclient.shaded.io.netty.util.concurrent.ImmediateEventExecutor;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
 
 public final class NingHttpRequestConverter {
 

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpResponse.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingHttpResponse.java
@@ -5,13 +5,13 @@ import com.hubspot.horizon.Header;
 import com.hubspot.horizon.Headers;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.internal.AbstractHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
-import org.asynchttpclient.shaded.Response;
-import org.asynchttpclient.shaded.io.netty.handler.codec.http.HttpHeaders;
+import org.asynchttpclient.Response;
 
 public class NingHttpResponse extends AbstractHttpResponse {
 

--- a/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingSSLContext.java
+++ b/HorizonNing/src/main/java/com/hubspot/horizon/ning/internal/NingSSLContext.java
@@ -1,11 +1,11 @@
 package com.hubspot.horizon.ning.internal;
 
 import com.hubspot.horizon.SSLConfig;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import javax.net.ssl.SSLException;
-import org.asynchttpclient.shaded.io.netty.handler.ssl.SslContext;
-import org.asynchttpclient.shaded.io.netty.handler.ssl.SslContextBuilder;
-import org.asynchttpclient.shaded.io.netty.handler.ssl.SslProvider;
-import org.asynchttpclient.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 public final class NingSSLContext {
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.4</version>
+    <version>63.6</version>
   </parent>
 
   <artifactId>Horizon</artifactId>
-  <version>0.3.4-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -24,9 +24,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>async-http-client-shaded</artifactId>
-        <version>2.12.1.0</version>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>3.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.hubspot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.6</version>
+    <version>63.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>Horizon</artifactId>


### PR DESCRIPTION
The interesting bit of this upgrade, is that async-http-client introduces a new feature in v3, `enableAutomaticDecompression`. This uses a netty-codec implementation, which for snappy, implements frame-based decompression. This is incompatible with non-frame-based snappy compression, which our previous code expects, from the unit tests.

See: https://github.com/xerial/snappy-java?tab=readme-ov-file#data-format-compatibility-matrix

This also updates the dependency tree to use unshaded netty, at the current expected level of async-http-client (4.1).
